### PR TITLE
Fix: 모니터링 페이지 레포 이름 입력

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -9,10 +9,10 @@ function Button(props: any) {
     else if (props.text === "back") return "이전으로";
   };
   const goTo = () => {
-    const value = props.value;
+    const value = props.state;
     if (props.text === "home") navigate("/");
     else if (props.text === "monitor")
-      navigate("/monitor", { state: { value } });
+      navigate("/monitor", { state: { repoName: value } });
     else if (props.text === "back") navigate(-1);
   };
   return (


### PR DESCRIPTION
- props.value -> props.state로 수정
- state: value로 넘겨주던 값을 state: { repoName: value } 로 변경
- 정상적으로 레포 이름을 출력하는 것을 확인